### PR TITLE
Fixed warning on macOS Mojave

### DIFF
--- a/lib/external/TessellateS3/compileTessellate.m
+++ b/lib/external/TessellateS3/compileTessellate.m
@@ -2,7 +2,7 @@ if ispc
     mex tessellate_S3.cpp hypersphere.cpp tetramesh.cpp octetramesh.cpp util.cpp
 elseif ismac
     %todo test
-    mex CFLAGS='-I/usr/include/malloc' tessellate_S3.cpp hypersphere.cpp tetramesh.cpp octetramesh.cpp util.cpp
+    mex CFLAGS='$CFLAGS -I/usr/include/malloc' tessellate_S3.cpp hypersphere.cpp tetramesh.cpp octetramesh.cpp util.cpp
 else
     %linux
     mex CFLAGS='$CFLAGS' tessellate_S3.cpp hypersphere.cpp tetramesh.cpp octetramesh.cpp util.cpp


### PR DESCRIPTION
This fix removes a warning thrown by the linker when compiling the C code on macOS Mojave.