### PR TITLE
Added Association likelihood calculation for MTT.

### DIFF
--- a/lib/filters/CircularParticleFilter.m
+++ b/lib/filters/CircularParticleFilter.m
@@ -142,6 +142,11 @@ classdef CircularParticleFilter < AbstractCircularFilter & HypertoroidalParticle
         end
         
         function likelihoodVal=associationLikelihood(this,likelihood)
+            % see Florian Pfaff, Kailai Li, and Uwe D. Hanebeck,
+            % Association Likelihoods for Directional Estimation
+            % Proceedings of the 2019 IEEE International Conference on
+            % Multisensor Fusion and Integration for Intelligent Systems (MFI 2019),
+            % Taipei, Republic of China, May, 2019.
             likelihoodVal=sum(likelihood.pdf(this.getEstimate.d).*this.getEstimate.w);
         end
     end

--- a/lib/filters/CircularParticleFilter.m
+++ b/lib/filters/CircularParticleFilter.m
@@ -147,7 +147,7 @@ classdef CircularParticleFilter < AbstractCircularFilter & HypertoroidalParticle
             % Proceedings of the 2019 IEEE International Conference on
             % Multisensor Fusion and Integration for Intelligent Systems (MFI 2019),
             % Taipei, Republic of China, May, 2019.
-            likelihoodVal=sum(likelihood.pdf(this.getEstimate.d).*this.getEstimate.w);
+            likelihoodVal = sum(likelihood.pdf(this.getEstimate.d).*this.getEstimate.w);
         end
     end
     

--- a/lib/filters/CircularParticleFilter.m
+++ b/lib/filters/CircularParticleFilter.m
@@ -140,6 +140,10 @@ classdef CircularParticleFilter < AbstractCircularFilter & HypertoroidalParticle
             end
             this.wd = WDDistribution(this.wd.sample(length(this.wd.d))); %use SIR.
         end
+        
+        function likelihoodVal=associationLikelihood(this,likelihood)
+            likelihoodVal=sum(likelihood.pdf(this.getEstimate.d).*this.getEstimate.w);
+        end
     end
     
 end

--- a/lib/filters/FourierFilter.m
+++ b/lib/filters/FourierFilter.m
@@ -280,6 +280,11 @@ classdef FourierFilter < AbstractCircularFilter
         end
         
         function likelihoodVal = associationLikelihood(this, likelihood)
+            % see Florian Pfaff, Kailai Li, and Uwe D. Hanebeck,
+            % Association Likelihoods for Directional Estimation
+            % Proceedings of the 2019 IEEE International Conference on
+            % Multisensor Fusion and Integration for Intelligent Systems (MFI 2019),
+            % Taipei, Republic of China, May, 2019.
             assert(numel(this.getEstimate.a) == numel(likelihood.a));
             assert(numel(this.getEstimate.transformation) == numel(likelihood.transformation));
             

--- a/lib/filters/VMFilter.m
+++ b/lib/filters/VMFilter.m
@@ -366,8 +366,10 @@ classdef VMFilter < AbstractCircularFilter
             % Proceedings of the 2019 IEEE International Conference on
             % Multisensor Fusion and Integration for Intelligent Systems (MFI 2019),
             % Taipei, Republic of China, May, 2019.
-            vmEst=this.getEstimate.multiply(likelihood);
-            likelihoodVal=besseli(0,vmEst.kappa)/(2*pi*besseli(0,this.getEstimate.kappa)*besseli(0,likelihood.kappa));
+            vmEst = this.getEstimate.multiply(likelihood);
+            likelihoodVal = besseli(0, vmEst.kappa) ...
+                / (2 * pi * besseli(0, this.getEstimate.kappa)...
+                * besseli(0, likelihood.kappa));
         end
     end
     

--- a/lib/filters/VMFilter.m
+++ b/lib/filters/VMFilter.m
@@ -361,6 +361,11 @@ classdef VMFilter < AbstractCircularFilter
         end
         
         function likelihoodVal=associationLikelihood(this,likelihood)
+            % see Florian Pfaff, Kailai Li, and Uwe D. Hanebeck,
+            % Association Likelihoods for Directional Estimation
+            % Proceedings of the 2019 IEEE International Conference on
+            % Multisensor Fusion and Integration for Intelligent Systems (MFI 2019),
+            % Taipei, Republic of China, May, 2019.
             vmEst=this.getEstimate.multiply(likelihood);
             likelihoodVal=besseli(0,vmEst.kappa)/(2*pi*besseli(0,this.getEstimate.kappa)*besseli(0,likelihood.kappa));
         end

--- a/lib/filters/VMFilter.m
+++ b/lib/filters/VMFilter.m
@@ -359,6 +359,11 @@ classdef VMFilter < AbstractCircularFilter
             %       current estimate
             vm = this.vm;
         end
+        
+        function likelihoodVal=associationLikelihood(this,likelihood)
+            vmEst=this.getEstimate.multiply(likelihood);
+            likelihoodVal=besseli(0,vmEst.kappa)/(2*pi*besseli(0,this.getEstimate.kappa)*besseli(0,likelihood.kappa));
+        end
     end
     
 end

--- a/lib/tests/filters/CircularParticleFilterTest.m
+++ b/lib/tests/filters/CircularParticleFilterTest.m
@@ -97,5 +97,14 @@ classdef CircularParticleFilterTest < matlab.unittest.TestCase
             testCase.verifyEqual(wd3a.d, wd3c.d);
             testCase.verifyEqual(wd3a.w, wd3c.w);
         end
+        function testAssociationLikelihood(testCase)
+            wd=WDDistribution([1,2,3],[1/3,1/3,1/3]);
+            pf=CircularParticleFilter(3);
+            pf.setState(wd);
+
+            testCase.verifyEqual(pf.associationLikelihood(CircularUniformDistribution),...
+                1/(2*pi), 'AbsTol', 1E-10);
+            testCase.verifyGreaterThan(pf.associationLikelihood(VMDistribution(2,1)),1/(2*pi));
+        end
     end
 end

--- a/lib/tests/filters/VMFilterTest.m
+++ b/lib/tests/filters/VMFilterTest.m
@@ -158,5 +158,13 @@ classdef VMFilterTest < matlab.unittest.TestCase
             testCase.verifyEqual(vm.mu, vmNonlinCorrectedNoiseIdentity.mu, 'RelTol', 1E-10);
             testCase.verifyEqual(vmNonlinCorrectedNoiseIdentity.kappa, vmIdentity.kappa, 'RelTol', 1E-10);            
         end
+        
+        function testAssociationLikelihood(testCase)
+            vm1=VMDistribution(3,3);
+            vm2=VMDistribution(1,10);
+            vmfilter=VMFilter;
+            vmfilter.setState(vm1);
+            testCase.verifyEqual(vmfilter.associationLikelihood(vm2), vmfilter.associationLikelihoodNumerical(vm2), 'AbsTol', 1E-10);
+        end
     end
 end


### PR DESCRIPTION
This implementation is just for validation and testing purposes. In actual applications for MTT, all combinations should be calculated at once for higher performance.