### PR TITLE
Added function meanDirection for all distributions. The result is equ…

### DIFF
--- a/lib/distributions/Hypersphere/AbstractHypersphericalDistribution.m
+++ b/lib/distributions/Hypersphere/AbstractHypersphericalDistribution.m
@@ -68,6 +68,40 @@ classdef AbstractHypersphericalDistribution
             end
         end
         
+        function mu = meanDirection(this)
+            % Calculate mean direction of pdf
+            % Returns:
+            %   mu (vector)
+            %       mean direction
+            mu = meanDirectionNumerical(this);
+        end
+        
+        function mu = meanDirectionNumerical(this)
+            % Calculate mean direction of pdf
+            % Returns:
+            %   mu (vector)
+            %       mean direction
+            mu=NaN(3,1);
+            for i=1:3
+                f = @(x) x(i,:).*this.pdf(x);
+                r=1;
+                
+                % spherical coordinates
+                fangles = @(phi1,phi2) f([ ...
+                r.*sin(phi1).*sin(phi2); ...
+                r.*cos(phi1).*sin(phi2); ...
+                r.*cos(phi2); ...
+                ]);
+
+                g = @(phi1,phi2) reshape(fangles(phi1(:)',phi2(:)').*sin(phi2(:)'),size(phi1)); % volume correcting term
+                mu(i) = integral2(g, 0, 2*pi, 0, pi, 'AbsTol', 1e-3, 'RelTol', 1e-3);
+            end
+            if norm(mu)<1e-9
+                warning('Density may not have actually have a mean direction because integral yields a point very close to the origin.')
+            end
+            mu = mu/norm(mu);
+        end
+        
         function i = integral(this)
             % Calculate integral of pdf to check normalization
             % (should always be 1)
@@ -318,7 +352,7 @@ classdef AbstractHypersphericalDistribution
             %
             % Parameters:
             %   other (AbstractHypersphericalDistribution)
-            %       distribution to compare to
+            %       distribution to compare with
             % Returns:
             %   dist (scalar)
             %       total variation distance of this distribution to other distribution

--- a/lib/distributions/Hypersphere/HypersphericalDiracDistribution.m
+++ b/lib/distributions/Hypersphere/HypersphericalDiracDistribution.m
@@ -163,6 +163,11 @@ classdef HypersphericalDiracDistribution < AbstractHypersphericalDistribution
             % Placeholder, pdf does not exist for Dirac distributions
             error('PDF:UNDEFINED', 'pdf is not defined')
         end     
+        
+        function mu = meanDirection(this)
+            vecSum = sum(this.d.*this.w, 2);
+            mu = vecSum/norm(vecSum);
+        end
     end
 end
 

--- a/lib/distributions/Hypersphere/SphericalHarmonicsDistributionComplex.m
+++ b/lib/distributions/Hypersphere/SphericalHarmonicsDistributionComplex.m
@@ -273,7 +273,7 @@ classdef SphericalHarmonicsDistributionComplex < AbstractSphericalHarmonicsDistr
             shd = this;
             shd.coeffMat = coeffMatRot; % Do not use constructor to skip normalization test
         end
-        function mu = mean(this)
+        function mu = meanDirection(this)
             if ~(size(this.coeffMat) > 1)
                 error('Too few coefficients available to calculate the mean');
             end
@@ -302,9 +302,13 @@ classdef SphericalHarmonicsDistributionComplex < AbstractSphericalHarmonicsDistr
             if nargin == 2 % Default to identity
                 transformation = 'identity';
             end
-            shd = SphericalHarmonicsDistributionComplex.fromDistributionFast(dist, degree, transformation);
+            if isa(dist,'SphericalGridDistribution')
+                shd = SphericalHarmonicsDistributionComplex.fromGrid(this.fvals, this.grid, transformation);
+            else
+                shd = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(dist, degree, transformation);
+            end
         end
-        function shd = fromDistributionFast(dist, degree, transformation)
+        function shd = fromDistributionNumericalFast(dist, degree, transformation)
             % Just a convenience function to call from function
             if nargin == 2 % Default to identity
                 transformation = 'identity';

--- a/lib/distributions/Hypersphere/SphericalHarmonicsDistributionReal.m
+++ b/lib/distributions/Hypersphere/SphericalHarmonicsDistributionReal.m
@@ -47,7 +47,7 @@ classdef SphericalHarmonicsDistributionReal < AbstractSphericalHarmonicsDistribu
             shdComplexRot = shdComplex.rotate(alpha, beta, gamma);
             shd = shdComplexRot.toSphericalHarmonicsDistributionReal;
         end
-        function mu = mean(this)
+        function mu = meanDirection(this)
             if ~strcmp(this.transformation, 'identity')
                 error('Transformation currently not supported')
             end

--- a/lib/distributions/Hypersphere/VMFDistribution.m
+++ b/lib/distributions/Hypersphere/VMFDistribution.m
@@ -24,7 +24,7 @@ classdef VMFDistribution < AbstractHypersphericalDistribution
             %       concentration parameter (>=0)
             epsilon = 1E-6;
             assert(size(mu_,2) == 1, 'mu must be a column vector');
-            assert(size(mu_,1) >= 2, 'mu must be at least 2 for the circular case');
+            assert(size(mu_,1) >= 2, 'mu must be at least two-dimensinal for the circular case');
             assert(abs(norm(mu_) - 1)<epsilon, 'mu must be a normalized');
             assert(kappa_>=0, 'kappa must be postive');
             
@@ -51,6 +51,10 @@ classdef VMFDistribution < AbstractHypersphericalDistribution
             assert (size(xa,1) == size(this.mu,1));
             
             p = this.C * exp( this.kappa * this.mu' * xa);
+        end
+        
+        function mu = meanDirection(this)
+           mu = this.mu;
         end
         
         function samples = sampleDeterministic(this)

--- a/lib/distributions/Hypertorus/AbstractHypertoroidalDistribution.m
+++ b/lib/distributions/Hypertorus/AbstractHypertoroidalDistribution.m
@@ -68,6 +68,11 @@ classdef AbstractHypertoroidalDistribution
             m = mod(atan2(imag(a),real(a)), 2*pi);
         end
         
+        function m = meanDirection(this)
+            % More general name for circular mean.
+            m = circularMean(this);
+        end
+        
         function m = trigonometricMoment(this, n)
             % Calculate n-th trigonometric moment, i.e., 
             % E([e^(inx_1); e^(inx_2);...^e(inx_d)])

--- a/lib/filters/AbstractHypersphericalFilter.m
+++ b/lib/filters/AbstractHypersphericalFilter.m
@@ -10,6 +10,10 @@ classdef AbstractHypersphericalFilter < handle
     methods (Abstract)
         setState(this, state)
         est = getEstimate(this)
-        mean = getEstimateMean(this)
+    end
+    methods 
+        function mean = getEstimateMean(this)
+            mean = this.getEstimate.meanDirection;
+        end
     end
 end

--- a/lib/filters/HypersphericalParticleFilter.m
+++ b/lib/filters/HypersphericalParticleFilter.m
@@ -127,16 +127,6 @@ classdef HypersphericalParticleFilter < AbstractHypersphericalFilter
             %       current estimate            
             wd = this.wd;
         end
-        
-        function mean=getEstimateMean(this)
-            % Return mean of current estimate 
-            %
-            % Returns:
-            %   mean (column vector)
-            %       current estimate mean (normalized)
-            vecSum = sum(this.wd.d.*repmat(this.wd.w,this.dim,1),2);
-            mean = vecSum/norm(vecSum);
-        end
     end
     
 end

--- a/lib/filters/SphericalHarmonicsFilter.m
+++ b/lib/filters/SphericalHarmonicsFilter.m
@@ -40,7 +40,7 @@ classdef SphericalHarmonicsFilter < AbstractHypersphericalFilter
         end
         
         function mean = getEstimateMean(this)
-            mean = this.state.mean;
+            mean = this.state.meanDirection;
         end
         
         function predictIdentity(this, sysNoise)
@@ -56,7 +56,7 @@ classdef SphericalHarmonicsFilter < AbstractHypersphericalFilter
         function updateIdentity(this, measNoise, z)
             % Splitting the noise into a noise term and a measurement is not a
             % universal solution. This function was added for interface
-            % compatibility of the VMF Filter. If z is used, measNoise needs to be
+            % compatibility with the VMF Filter. If z is used, measNoise needs to be
             % zonal with rotational symmetry around the z-axis and have a
             % mean of [0;0;1].
             % It is possible to use 0 or [0;0;1] as measurement if no rotation should be

--- a/lib/tests/distributions/AbstractHypersphericalDistributionTest.m
+++ b/lib/tests/distributions/AbstractHypersphericalDistributionTest.m
@@ -67,6 +67,12 @@ classdef AbstractHypersphericalDistributionTest< matlab.unittest.TestCase
             testCase.verifyEqual(sum(s2.^2,1), ones(1,n), 'RelTol', 1E-10);
         end
         
+        function testMeanDirectionNumerical(testCase)
+            mu = 1/sqrt(2)*[1;1;0];
+            vmf = VMFDistribution(mu,1);
+            testCase.verifyEqual(vmf.meanDirectionNumerical, mu, 'AbsTol', 1e-6);
+        end
+        
         function testDistances(testCase)
             for dim=2:4
                 dist1=VMFDistribution([1;0;zeros(dim-2,1)],2);

--- a/lib/tests/distributions/AbstractSphericalHarmonicsDistributionTest.m
+++ b/lib/tests/distributions/AbstractSphericalHarmonicsDistributionTest.m
@@ -19,29 +19,29 @@ classdef AbstractSphericalHarmonicsDistributionTest < matlab.unittest.TestCase
                 shdZonalCurr = shdZonals{i};
                 shdtmp = shdRandomCurr.convolve(shdZonalCurr);
                 testCase.verifySize(shdtmp.coeffMat, [7, 13]);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-10);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-4);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-10);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-4);
                 
                 shdtmp = shdRandomCurr.convolve(shdZonalCurr.truncate(5));
                 testCase.verifySize(shdtmp.coeffMat, [6, 11]);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-10);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-10);
                 testCase.verifyEqual(shdtmp.integralNumerical, 1, 'AbsTol', 1E-4);
                 
                 shdtmp = shdRandomCurr.convolve(shdZonalCurr.truncate(4));
                 testCase.verifySize(shdtmp.coeffMat, [5, 9]);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-10);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-10);
                 testCase.verifyEqual(shdtmp.integralNumerical, 1, 'AbsTol', 1E-4);
                 
                 shdRandomTrunc = shdRandomCurr.truncate(5);
                 shdtmp = shdRandomTrunc.convolve(shdZonalCurr);
                 testCase.verifySize(shdtmp.coeffMat, [6, 11]);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-10);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-10);
                 testCase.verifyEqual(shdtmp.integralNumerical, 1, 'AbsTol', 1E-4);
                 
                 shdRandomTrunc = shdRandomCurr.truncate(4);
                 shdtmp = shdRandomTrunc.convolve(shdZonalCurr);
                 testCase.verifySize(shdtmp.coeffMat, [5, 9]);
-                testCase.verifyEqual(shdtmp.mean, shdRandomCurr.mean, 'AbsTol', 1E-10);
+                testCase.verifyEqual(shdtmp.meanDirection, shdRandomCurr.meanDirection, 'AbsTol', 1E-10);
                 testCase.verifyEqual(shdtmp.integralNumerical, 1, 'AbsTol', 1E-4);
             end
         end
@@ -56,7 +56,7 @@ classdef AbstractSphericalHarmonicsDistributionTest < matlab.unittest.TestCase
             kappaBeforePredict = 1;
             
             fBeforePredict = VMFDistribution([0; 1; 0], kappaBeforePredict);
-            shdBeforePredict = SphericalHarmonicsDistributionComplex.fromDistributionFast(fBeforePredict, order);
+            shdBeforePredict = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(fBeforePredict, order);
             
             fTran = @(mu, xkk)vmfpdf(xkk, mu, kappaTran);
             r = 1;
@@ -80,7 +80,7 @@ classdef AbstractSphericalHarmonicsDistributionTest < matlab.unittest.TestCase
             
             chd = CustomHypersphericalDistribution(fpredArrayfun, 3);
             
-            shdTrans = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([0; 0; 1], kappaTran), order);
+            shdTrans = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([0; 0; 1], kappaTran), order);
             shdRes = shdBeforePredict.convolve(shdTrans);
             
             testCase.verifyEqual(shdRes.hellingerDistanceNumerical(chd), 0, 'AbsTol', 1E-10);

--- a/lib/tests/distributions/SphericalHarmonicsDistributionComplexTest.m
+++ b/lib/tests/distributions/SphericalHarmonicsDistributionComplexTest.m
@@ -312,13 +312,13 @@ classdef SphericalHarmonicsDistributionComplexTest < matlab.unittest.TestCase
         function testTransformViaCoefficients(testCase)
             degree = 21;
             % Test identity -> sqrt
-            shd = SphericalHarmonicsDistributionComplex.fromDistributionFast( ...
+            shd = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast( ...
                 VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'identity');
             shdSqrt = shd.transformViaCoefficients('sqrt', degree);
             testCase.verifyEqual(shdSqrt.totalVariationDistanceNumerical(shd), 0, 'AbsTol', 1E-14);
             testCase.verifySize(shdSqrt.coeffMat, [degree + 1, 2 * degree + 1]);
             % Test sqrt -> identity
-            shd = SphericalHarmonicsDistributionComplex.fromDistributionFast( ...
+            shd = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast( ...
                 VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'sqrt');
             shdId = shd.transformViaCoefficients('square', degree-1);
             testCase.verifySize(shdId.coeffMat, [(degree - 1) + 1, 2 * (degree - 1) + 1]);
@@ -331,8 +331,8 @@ classdef SphericalHarmonicsDistributionComplexTest < matlab.unittest.TestCase
             wignercycle(10);
             warningSetting = warning('off', 'Normalization:notNormalized');
             for transformation = {'identity', 'sqrt'}
-                shd1 = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([1; 1; 1]/sqrt(3), 2), 5, [transformation{:}]);
-                shd2 = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([1; 1; -1]/sqrt(3), 2), 5, [transformation{:}]);
+                shd1 = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([1; 1; 1]/sqrt(3), 2), 5, [transformation{:}]);
+                shd2 = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([1; 1; -1]/sqrt(3), 2), 5, [transformation{:}]);
                 warning(warningSetting);
                 shdMultFast = shd1.multiply(shd2);
                 shdMultCoeff = shd1.multiplyViaCoefficients(shd2);
@@ -356,11 +356,11 @@ classdef SphericalHarmonicsDistributionComplexTest < matlab.unittest.TestCase
             % transformation, given a sufficiently high number of
             % coefficients.
             degree = 21;
-            thisId = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'identity');
-            otherId = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([0; 0; 1], 1), degree, 'identity');
+            thisId = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'identity');
+            otherId = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([0; 0; 1], 1), degree, 'identity');
             
-            this = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'sqrt');
-            other = SphericalHarmonicsDistributionComplex.fromDistributionFast(VMFDistribution([0; 0; 1], 1), degree, 'sqrt');
+            this = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([1; 1; 0]/sqrt(2), 2), degree, 'sqrt');
+            other = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(VMFDistribution([0; 0; 1], 1), degree, 'sqrt');
             
             convolutionResultId = thisId.convolve(otherId);
             convolutionResultSqrt = this.convolve(other);
@@ -442,22 +442,22 @@ classdef SphericalHarmonicsDistributionComplexTest < matlab.unittest.TestCase
         end
         function testMean(testCase)
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; 0, 1, 0]);
-            testCase.verifyEqual(shd.mean, [0; 0; 1], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [0; 0; 1], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; 0, -1, 0]);
-            testCase.verifyEqual(shd.mean, [0; 0; -1], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [0; 0; -1], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; 1i * sqrt(1/2), 0, 1i * sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, [0; 1; 0], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [0; 1; 0], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; -1i * sqrt(1/2), 0, -1i * sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, [0; -1; 0], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [0; -1; 0], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; sqrt(1/2), 0, -sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, [1; 0; 0], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [1; 0; 0], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; -sqrt(1/2), 0, sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, [-1; 0; 0], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, [-1; 0; 0], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; -1i * sqrt(1/2) - sqrt(1/2), 0, -1i * sqrt(1/2) + sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, 1/sqrt(2)*[-1; -1; 0], 'AbsTol', 1E-6);
+            testCase.verifyEqual(shd.meanDirection, 1/sqrt(2)*[-1; -1; 0], 'AbsTol', 1E-6);
             shd = SphericalHarmonicsDistributionComplex([1 / sqrt(4*pi), NaN, NaN; 1i * sqrt(1/2) + sqrt(1/2), 1, 1i * sqrt(1/2) - sqrt(1/2)]);
-            testCase.verifyEqual(shd.mean, 1/sqrt(3)*[1; 1; 1], 'AbsTol', 1E-6);
-            testCase.verifyTrue(isreal(shd.mean));
+            testCase.verifyEqual(shd.meanDirection, 1/sqrt(3)*[1; 1; 1], 'AbsTol', 1E-6);
+            testCase.verifyTrue(isreal(shd.meanDirection));
         end
         function integralAnalytical(testCase)
             coeffRand = rand(1, 9);
@@ -468,14 +468,14 @@ classdef SphericalHarmonicsDistributionComplexTest < matlab.unittest.TestCase
             warning(warningSettings);
             testCase.verifyEqual(shd.integralAnalytical, shd.integral, 'AbsTol', 1E-6);
         end
-        function testFromDistributionFast(testCase)
+        function testfromDistributionNumericalFast(testCase)
             [phi, theta] = meshgrid(linspace(0, 2*pi, 30), linspace(-pi/2, pi/2, 30));
             [x, y, z] = sph2cart(phi(:)', theta(:)', 1);
             dists = {VMFDistribution([1; 0; 0], 1), VMFDistribution([0; 1; 0], 2), VMFDistribution([0; 0; 1], 3), ...
                 HypersphericalMixture({VMFDistribution([1; 1; 1]/sqrt(3), 3), VMFDistribution([1; 0; 0], 2)}, [0.5, 0.5])};
             for transformation = {'identity', 'sqrt'}
                 for i = 1:numel(dists)
-                    shd = SphericalHarmonicsDistributionComplex.fromDistributionFast(dists{i}, 21, [transformation{:}]);
+                    shd = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(dists{i}, 21, [transformation{:}]);
                     testCase.verifyEqual(dists{i}.pdf([x; y; z]), shd.pdf([x; y; z]), 'AbsTol', 1E-6)
                 end
             end

--- a/lib/tests/distributions/VMFDistributionTest.m
+++ b/lib/tests/distributions/VMFDistributionTest.m
@@ -181,6 +181,12 @@ classdef VMFDistributionTest< matlab.unittest.TestCase
             testCase.verifyEqual(g.mu, vmf.mu);
         end
         
+        function testMeanDirection(testCase)
+            mu = 1/sqrt(2)*[1;1;0];
+            vmf = VMFDistribution(mu,1);
+            testCase.verifyEqual(vmf.meanDirection, mu, 'AbsTol', 1e-13);
+        end
+        
         function testHellinger(testCase)
             % 2D
             vmf1 = VMFDistribution([1,0]', 0.9);

--- a/lib/tests/distributions/WDDistributionTest.m
+++ b/lib/tests/distributions/WDDistributionTest.m
@@ -153,7 +153,7 @@ classdef WDDistributionTest< matlab.unittest.TestCase
             testCase.verifyEqual(cd2.totalVariationDistanceNumerical(cd),0, 'RelTol', 1E-10);
             
             wd3=WDDistribution([d d],[w/2 w/2]);
-            cd3=wd2.toContinuousVoronoi;
+            cd3=wd3.toContinuousVoronoi;
             testCase.verifyEqual(cd3.totalVariationDistanceNumerical(cd),0, 'RelTol', 1E-10);
         end
         

--- a/lib/tests/filters/SphericalHarmonicsFilterTest.m
+++ b/lib/tests/filters/SphericalHarmonicsFilterTest.m
@@ -8,8 +8,8 @@ classdef SphericalHarmonicsFilterTest < matlab.unittest.TestCase
                 
                 vmf1 = VMFDistribution([0; 1; 0], 1);
                 vmf2 = VMFDistribution([0; 0; 1], 0.1);
-                shd1 = SphericalHarmonicsDistributionComplex.fromDistributionFast(vmf1, 30);
-                shd2 = SphericalHarmonicsDistributionComplex.fromDistributionFast(vmf2, 30);
+                shd1 = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(vmf1, 30);
+                shd2 = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(vmf2, 30);
                 
                 warnStruct = warning('off', 'SphericalHarmonicsFilter:rotationRequired');
                 vmfFilter.setState(vmf1);
@@ -93,10 +93,10 @@ classdef SphericalHarmonicsFilterTest < matlab.unittest.TestCase
             densityInit = VMFDistribution([1; 1; 0]/sqrt(2), 2);
             sysNoise = VMFDistribution([0; 0; 1], 1);
             
-            shdInitId = SphericalHarmonicsDistributionComplex.fromDistributionFast(densityInit, degree, 'identity');
-            shdInitSqrt = SphericalHarmonicsDistributionComplex.fromDistributionFast(densityInit, degree, 'sqrt');
-            shdNoiseId = SphericalHarmonicsDistributionComplex.fromDistributionFast(sysNoise, degree, 'identity');
-            shdNoiseSqrt = SphericalHarmonicsDistributionComplex.fromDistributionFast(sysNoise, degree, 'sqrt');
+            shdInitId = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(densityInit, degree, 'identity');
+            shdInitSqrt = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(densityInit, degree, 'sqrt');
+            shdNoiseId = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(sysNoise, degree, 'identity');
+            shdNoiseSqrt = SphericalHarmonicsDistributionComplex.fromDistributionNumericalFast(sysNoise, degree, 'sqrt');
             
             shFilter1 = SphericalHarmonicsFilter(degree, 'identity');
             shFilter2 = SphericalHarmonicsFilter(degree, 'sqrt');


### PR DESCRIPTION
Added function meanDirection for all distributions. The result is equal to the circular mean for hypertoroidal distributions. For hyperspherical distributions, numerical calculation is used. However, closed form solutions are provided for some distributions. The function meanDirection is also now used by getEstimateMean of the filters.
Plus: Renaming of fromDistributionFast in Spherical Harmonics Distribution and some minor changes.